### PR TITLE
tiny improvement in error message

### DIFF
--- a/src/snowflake/snowflake.py
+++ b/src/snowflake/snowflake.py
@@ -24,7 +24,7 @@ class Snowflake:
 
     def __post_init__(self):
         if self.epoch < 0:
-            raise ValueError(f"epoch must be greater than or equal to 0!")
+            raise ValueError("epoch must be greater than or equal to 0!")
 
         if self.timestamp < 0 or self.timestamp > MAX_TS:
             raise ValueError(f"timestamp must not be negative and must be less than {MAX_TS}!")

--- a/src/snowflake/snowflake.py
+++ b/src/snowflake/snowflake.py
@@ -24,7 +24,7 @@ class Snowflake:
 
     def __post_init__(self):
         if self.epoch < 0:
-            raise ValueError(f"epoch must be greater than 0!")
+            raise ValueError(f"epoch must be greater than or equal to 0!")
 
         if self.timestamp < 0 or self.timestamp > MAX_TS:
             raise ValueError(f"timestamp must not be negative and must be less than {MAX_TS}!")

--- a/src/snowflake/snowflake.py
+++ b/src/snowflake/snowflake.py
@@ -24,7 +24,7 @@ class Snowflake:
 
     def __post_init__(self):
         if self.epoch < 0:
-            raise ValueError("epoch must be greater than or equal to 0!")
+            raise ValueError("epoch must not be negative!")
 
         if self.timestamp < 0 or self.timestamp > MAX_TS:
             raise ValueError(f"timestamp must not be negative and must be less than {MAX_TS}!")

--- a/tests/test_snowflake.py
+++ b/tests/test_snowflake.py
@@ -77,7 +77,7 @@ def test_instance_overflow():
 def test_epoch_overflow():
     Snowflake(0, 0, epoch=0)
 
-    with pytest.raises(ValueError, match="epoch must be greater than 0!"):
+    with pytest.raises(ValueError, match="epoch must not be negative!"):
         Snowflake(0, 0, epoch=-1)
 
 


### PR DESCRIPTION
this pr makes a tiny improvement to the error message when the epoch is < 0. it also removes the f-string because it's not needed.