### PR TITLE
feat: add `mypy` typing support

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,11 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
-lock_version = "4.4.1"
-content_hash = "sha256:79ea5f8d6d331eca34bfaeca08d4a0aef1553e6661c24a64f6712964d5e3cf56"
+lock_version = "4.5.0"
+content_hash = "sha256:8d0d372025b84e7f1a71e36f031558009b1b7856e7d1c39a6c6841b8e356fc01"
+
+[[metadata.targets]]
+requires_python = "~=3.8"
 
 [[package]]
 name = "certifi"
@@ -151,6 +154,58 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.11.2"
+requires_python = ">=3.8"
+summary = "Optional static typing for Python"
+groups = ["dev"]
+dependencies = [
+    "mypy-extensions>=1.0.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+    "typing-extensions>=4.6.0",
+]
+files = [
+    {file = "mypy-1.11.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d42a6dd818ffce7be66cce644f1dff482f1d97c53ca70908dff0b9ddc120b77a"},
+    {file = "mypy-1.11.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:801780c56d1cdb896eacd5619a83e427ce436d86a3bdf9112527f24a66618fef"},
+    {file = "mypy-1.11.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41ea707d036a5307ac674ea172875f40c9d55c5394f888b168033177fce47383"},
+    {file = "mypy-1.11.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6e658bd2d20565ea86da7d91331b0eed6d2eee22dc031579e6297f3e12c758c8"},
+    {file = "mypy-1.11.2-cp310-cp310-win_amd64.whl", hash = "sha256:478db5f5036817fe45adb7332d927daa62417159d49783041338921dcf646fc7"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:75746e06d5fa1e91bfd5432448d00d34593b52e7e91a187d981d08d1f33d4385"},
+    {file = "mypy-1.11.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a976775ab2256aadc6add633d44f100a2517d2388906ec4f13231fafbb0eccca"},
+    {file = "mypy-1.11.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd953f221ac1379050a8a646585a29574488974f79d8082cedef62744f0a0104"},
+    {file = "mypy-1.11.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:57555a7715c0a34421013144a33d280e73c08df70f3a18a552938587ce9274f4"},
+    {file = "mypy-1.11.2-cp311-cp311-win_amd64.whl", hash = "sha256:36383a4fcbad95f2657642a07ba22ff797de26277158f1cc7bd234821468b1b6"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e8960dbbbf36906c5c0b7f4fbf2f0c7ffb20f4898e6a879fcf56a41a08b0d318"},
+    {file = "mypy-1.11.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:06d26c277962f3fb50e13044674aa10553981ae514288cb7d0a738f495550b36"},
+    {file = "mypy-1.11.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e7184632d89d677973a14d00ae4d03214c8bc301ceefcdaf5c474866814c987"},
+    {file = "mypy-1.11.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3a66169b92452f72117e2da3a576087025449018afc2d8e9bfe5ffab865709ca"},
+    {file = "mypy-1.11.2-cp312-cp312-win_amd64.whl", hash = "sha256:969ea3ef09617aff826885a22ece0ddef69d95852cdad2f60c8bb06bf1f71f70"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:37c7fa6121c1cdfcaac97ce3d3b5588e847aa79b580c1e922bb5d5d2902df19b"},
+    {file = "mypy-1.11.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a8a53bc3ffbd161b5b2a4fff2f0f1e23a33b0168f1c0778ec70e1a3d66deb86"},
+    {file = "mypy-1.11.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ff93107f01968ed834f4256bc1fc4475e2fecf6c661260066a985b52741ddce"},
+    {file = "mypy-1.11.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:edb91dded4df17eae4537668b23f0ff6baf3707683734b6a818d5b9d0c0c31a1"},
+    {file = "mypy-1.11.2-cp38-cp38-win_amd64.whl", hash = "sha256:ee23de8530d99b6db0573c4ef4bd8f39a2a6f9b60655bf7a1357e585a3486f2b"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:801ca29f43d5acce85f8e999b1e431fb479cb02d0e11deb7d2abb56bdaf24fd6"},
+    {file = "mypy-1.11.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:af8d155170fcf87a2afb55b35dc1a0ac21df4431e7d96717621962e4b9192e70"},
+    {file = "mypy-1.11.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7821776e5c4286b6a13138cc935e2e9b6fde05e081bdebf5cdb2bb97c9df81d"},
+    {file = "mypy-1.11.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:539c570477a96a4e6fb718b8d5c3e0c0eba1f485df13f86d2970c91f0673148d"},
+    {file = "mypy-1.11.2-cp39-cp39-win_amd64.whl", hash = "sha256:3f14cd3d386ac4d05c5a39a51b84387403dadbd936e17cb35882134d4f8f0d24"},
+    {file = "mypy-1.11.2-py3-none-any.whl", hash = "sha256:b499bc07dbdcd3de92b0a8b29fdf592c111276f6a12fe29c30f6c417dd546d12"},
+    {file = "mypy-1.11.2.tar.gz", hash = "sha256:7f9993ad3e0ffdc95c2a14b66dee63729f021968bff8ad911867579c65d13a79"},
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+requires_python = ">=3.5"
+summary = "Type system extensions for programs checked with the mypy type checker."
+groups = ["dev"]
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "packaging"
 version = "23.2"
 requires_python = ">=3.7"
@@ -230,6 +285,31 @@ marker = "python_version >= \"3.11\""
 files = [
     {file = "tomlkit-0.12.4-py3-none-any.whl", hash = "sha256:5cd82d48a3dd89dee1f9d64420aa20ae65cfbd00668d6f094d7578a78efbb77b"},
     {file = "tomlkit-0.12.4.tar.gz", hash = "sha256:7ca1cfc12232806517a8515047ba66a19369e71edf2439d0f5824f91032b6cc3"},
+]
+
+[[package]]
+name = "types-requests"
+version = "2.32.0.20240712"
+requires_python = ">=3.8"
+summary = "Typing stubs for requests"
+groups = ["dev"]
+dependencies = [
+    "urllib3>=2",
+]
+files = [
+    {file = "types-requests-2.32.0.20240712.tar.gz", hash = "sha256:90c079ff05e549f6bf50e02e910210b98b8ff1ebdd18e19c873cd237737c1358"},
+    {file = "types_requests-2.32.0.20240712-py3-none-any.whl", hash = "sha256:f754283e152c752e46e70942fa2a146b5bc70393522257bb85bd1ef7e019dcc3"},
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.12.2"
+requires_python = ">=3.8"
+summary = "Backported and Experimental Type Hints for Python 3.8+"
+groups = ["dev"]
+files = [
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,10 +47,25 @@ dev = [
     "pytest~=8.0.2",
     "ubump~=0.1.15; python_version >= '3.11'",
     "requests>=2.31.0",
+    "mypy>=1.11.2",
+    "types-requests>=2.32.0.20240712",
 ]
+
+[tool.pytest.ini_options]
+pythonpath = "src"
 
 [tool.ubump]
 template = "v${major}.${minor}.${patch}"
 message = "Bump to ${version}"
 tag = true
 files = ["src/snowflake/__init__.py"]
+
+[tool.mypy]
+strict = true
+show_error_context = true
+disallow_untyped_defs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+check_untyped_defs = true
+disallow_subclassing_any = true
+exclude = ["^tests/"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-pythonpath= src

--- a/src/snowflake/__init__.py
+++ b/src/snowflake/__init__.py
@@ -10,5 +10,5 @@ VERSION = "v1.0.2"
 __version__ = VERSION
 
 
-def version():
+def version() -> str:
     return VERSION

--- a/src/snowflake/snowflake.py
+++ b/src/snowflake/snowflake.py
@@ -6,7 +6,7 @@
 from dataclasses import dataclass
 from time import time
 from typing import Optional
-from datetime import datetime, timedelta, tzinfo
+from datetime import datetime as dt, timedelta, tzinfo
 
 __all__ = ('Snowflake', 'SnowflakeGenerator', 'MAX_TS', 'MAX_INSTANCE', 'MAX_SEQ')
 
@@ -22,7 +22,7 @@ class Snowflake:
     epoch: int = 0
     seq: int = 0
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.epoch < 0:
             raise ValueError("epoch must not be negative!")
 
@@ -53,11 +53,11 @@ class Snowflake:
         return self.milliseconds / 1000
 
     @property
-    def datetime(self) -> datetime:
-        return datetime.utcfromtimestamp(self.seconds)
+    def datetime(self) -> dt:
+        return dt.utcfromtimestamp(self.seconds)
 
-    def datetime_tz(self, tz: Optional[tzinfo] = None) -> datetime:
-        return datetime.fromtimestamp(self.seconds, tz=tz)
+    def datetime_tz(self, tz: Optional[tzinfo] = None) -> dt:
+        return dt.fromtimestamp(self.seconds, tz=tz)
 
     @property
     def timedelta(self) -> timedelta:
@@ -108,7 +108,7 @@ class SnowflakeGenerator:
     def epoch(self) -> int:
         return self._epo
 
-    def __iter__(self):
+    def __iter__(self) -> 'SnowflakeGenerator':
         return self
 
     def __next__(self) -> Optional[int]:

--- a/tools/create_release.py
+++ b/tools/create_release.py
@@ -3,7 +3,7 @@ import sys
 import requests
 
 
-def create_release(token: str, repo: str, release: str, body: str):
+def create_release(token: str, repo: str, release: str, body: str) -> None:
     response = requests.post(f"https://api.github.com/repos/{repo}/releases",
                              headers={"Authorization": f"Bearer {token}"},
                              json={"tag_name": release, "name": release, "body": body})
@@ -13,7 +13,7 @@ def create_release(token: str, repo: str, release: str, body: str):
         sys.exit(-1)
 
 
-def main():
+def main() -> None:
     try:
         token, repo, release, body_file = sys.argv[1:]
     except ValueError:


### PR DESCRIPTION
Hey, nice implementation of snowflake IDs! 🙌 
Thought I'd throw in some `mypy` support.

- Renamed the import of `datetime` to `dt` to fix `datetime()` property scope conflict
- Added `mypy` dependency with `types-requests`
- Enabled `strict` `mypy` rule
- Excluded `tests` folder from `mypy` type-checking
- Added `py.typed` file to indicate that typing is enabled on this project for consumers
- Replaced `pytest.ini` with equivalent `pyproject.toml` rules

If this is useful, I'm also happy to add in some pre-commit hooks and GitHub workflows?
May also be a good idea to have some linting in place as well - I'm happy to set up `ruff` in a separate PR if interested?